### PR TITLE
added block to default scope

### DIFF
--- a/app/models/punch.rb
+++ b/app/models/punch.rb
@@ -5,7 +5,7 @@ class Punch < ActiveRecord::Base
   before_validation :set_defaults
   validates :punchable_id, :punchable_type, :starts_at, :ends_at, :average_time, :hits, :presence => true
 
-  default_scope { order 'punches.average_time DESC' }
+  default_scope -> { order 'punches.average_time DESC' }
   scope :combos, -> { where 'punches.hits > 1' }
   scope :jabs, -> { where hits: 1 }
   scope :before, ->(time = nil) { where('punches.ends_at <= ?', time) unless time.nil? }


### PR DESCRIPTION
To add support after ruby 2.x.x . We just needed to call the scope's condition as a  block. Heroku is now no more accepting the blockless scope when ruby version is greater then 2.x.x.  I hope this pull request would resolve this issue for the upgraded ruby version based application.
